### PR TITLE
Universal service provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Via Composer
 $ composer require webkod3r/laravel-swivel
 ```
 
+Rgister the new service provider in your application:
+
+```php
+$app->register(LaravelSwivel\SwivelServiceProvider::class);
+```
+
 After installing the package you can copy the default configuration and replace
 it with your own. In order to do that copy the file inside
 `vendor/webkod3r/laravel-swivel/config/swivel.php` into your onw project.

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,13 @@
     "description": "Laravel wrapper for swivel component",
     "keywords": [
         "laravel",
+        "lumen",
         "swivel",
-        "webkod3r",
-        "features"
+        "features",
+        "feature-flags",
+        "behavior",
+        "component",
+        "webkod3r"
     ],
     "homepage": "https://github.com/webkod3r/laravel-swivel",
     "license": "MIT",
@@ -22,8 +26,7 @@
         "illuminate/container": "~5.4",
         "illuminate/http": "~5.4",
         "illuminate/support": "~5.4",
-        "psr/log": "^1.0",
-        "zumba/swivel": "^2.1"
+        "zumba/swivel": "^2.1.5"
     },
     "require-dev": {
         "mockery/mockery": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "47b01ee83cc169165a2150c44917b971",
+    "content-hash": "37b700f29348d08bc82825d9d4fff7d6",
     "packages": [
         {
             "name": "doctrine/inflector",

--- a/src/SwivelServiceProvider.php
+++ b/src/SwivelServiceProvider.php
@@ -7,14 +7,14 @@ use \Illuminate\Support\ServiceProvider;
 use \Illuminate\Foundation\Application as LaravelApplication;
 use \Laravel\Lumen\Application as LumenApplication;
 
-class LaravelSwivelServiceProvider extends ServiceProvider
+class SwivelServiceProvider extends ServiceProvider
 {
     /**
      * The package version.
      *
      * @var string
      */
-    const VERSION = '1.0.1';
+    const VERSION = '1.1.0';
 
     /**
      * Indicates if loading of the provider is deferred.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since this is a package that can be used by Laravel or Lumen applications, it is better to have a universal service provider name.
